### PR TITLE
Add AGENTS.md and fix pre-release version filtering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+## Build & Test Commands
+
+- **Full CI**: `make ci` - runs verify, check-license, lint, build, unit-tests
+- **Build**: `make build` - builds binary via Docker (uses Go 1.25)
+- **Test**: `make test` - runs unit tests with race detector
+- **Lint**: `make lint` - runs golangci-lint
+- **Format**: `make fmt` - formats code with goimports/gofmt
+- **Verify**: `make verify` - checks code generation and module sync
+
+## Dependencies
+
+- Uses vendored dependencies: always use `GOFLAGS="-mod=vendor"` or `-mod=vendor` flag
+- Go version: 1.25
+
+## Products
+
+This repo automates releases for multiple AppsCode products: `voyager`, `kubevault`, `kubedb`, `ace`, `stash`, `kubestash`.
+
+- **Bump minor version**: `make bump-release-minor PRODUCT=<product>` or `./hack/scripts/bump-release-minor.sh <product>`
+
+## CLI Commands
+
+The binary supports subcommands: `release`, `ace`, `kubedb`, `kubestash`, `kubevault`, `stash`, `virtualsecrets`, `voyager`, `list-versions`, `update-assets`, `update-bundles`, `update-envvars`.
+
+## CI
+
+- GitHub Actions uses Go 1.25 on `ubuntu-24.04`
+- Runs `make ci` on PRs and pushes to master

--- a/cmds/update_assets.go
+++ b/cmds/update_assets.go
@@ -241,12 +241,10 @@ func sortProductVersions(versions []saapi.ProductVersion) ([]saapi.ProductVersio
 	latestVersion := data[0].Version
 	for i := range data {
 		v := semver.MustParse(data[i].Version)
-		if !data[i].Show ||
-			strings.HasPrefix(v.Prerelease(), "alpha.") ||
-			strings.HasPrefix(v.Prerelease(), "beta.") {
+		if !data[i].Show || v.Prerelease() != "" {
 			continue
 		}
-		// Use the latest non alpha/beta release
+		// Use the latest non pre-release version
 		latestVersion = data[i].Version
 		break
 	}


### PR DESCRIPTION
## Summary
- Add AGENTS.md with build/test commands, dependencies, products, and CLI subcommands
- Fix pre-release version filtering to exclude all pre-releases (not just alpha/beta)