### PR TITLE
Add GitHub REST rate-limit transport

### DIFF
--- a/lib/github.go
+++ b/lib/github.go
@@ -19,9 +19,12 @@ package lib
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
+	"math"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -33,7 +36,10 @@ import (
 )
 
 const (
-	skew = 10 * time.Second
+	defaultSecondaryRetryDelay = time.Minute
+	defaultServerErrorDelay    = 5 * time.Second
+	maxSecondaryRetryDelay     = 15 * time.Minute
+	maxRateLimitRetryAttempts  = 8
 )
 
 func NewGitHubClient() *github.Client {
@@ -42,11 +48,14 @@ func NewGitHubClient() *github.Client {
 		panic(api.GitHubTokenKey + " env var is not set")
 	}
 
-	// Create the http client.
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: token},
-	)
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	tc := oauth2.NewClient(context.TODO(), ts)
+
+	baseTransport := tc.Transport
+	if baseTransport == nil {
+		baseTransport = http.DefaultTransport
+	}
+	tc.Transport = &rateLimitTransport{base: baseTransport}
 
 	return github.NewClient(tc)
 }
@@ -60,12 +69,6 @@ func ListLabelsByIssue(ctx context.Context, gh *github.Client, owner, repo strin
 	for {
 		labels, resp, err := gh.Issues.ListLabelsByIssue(ctx, owner, repo, number, opt)
 		switch e := err.(type) {
-		case *github.RateLimitError:
-			time.Sleep(time.Until(e.Rate.Reset.Add(skew)))
-			continue
-		case *github.AbuseRateLimitError:
-			time.Sleep(e.GetRetryAfter())
-			continue
 		case *github.ErrorResponse:
 			if e.Response.StatusCode == http.StatusNotFound {
 				log.Println(err)
@@ -99,12 +102,6 @@ func ListReleases(ctx context.Context, gh *github.Client, owner, repo string) ([
 	for {
 		releases, resp, err := gh.Repositories.ListReleases(ctx, owner, repo, opt)
 		switch e := err.(type) {
-		case *github.RateLimitError:
-			time.Sleep(time.Until(e.Rate.Reset.Add(skew)))
-			continue
-		case *github.AbuseRateLimitError:
-			time.Sleep(e.GetRetryAfter())
-			continue
 		case *github.ErrorResponse:
 			if e.Response.StatusCode == http.StatusNotFound {
 				log.Println(err)
@@ -136,12 +133,6 @@ func ListReviews(ctx context.Context, gh *github.Client, owner, repo string, num
 	for {
 		reviews, resp, err := gh.PullRequests.ListReviews(ctx, owner, repo, number, opt)
 		switch e := err.(type) {
-		case *github.RateLimitError:
-			time.Sleep(time.Until(e.Rate.Reset.Add(skew)))
-			continue
-		case *github.AbuseRateLimitError:
-			time.Sleep(e.GetRetryAfter())
-			continue
 		case *github.ErrorResponse:
 			if e.Response.StatusCode == http.StatusNotFound {
 				log.Println(err)
@@ -177,12 +168,6 @@ func ListPullRequestComment(ctx context.Context, gh *github.Client, owner, repo 
 	for {
 		comments, resp, err := gh.PullRequests.ListComments(ctx, owner, repo, number, opt)
 		switch e := err.(type) {
-		case *github.RateLimitError:
-			time.Sleep(time.Until(e.Rate.Reset.Add(skew)))
-			continue
-		case *github.AbuseRateLimitError:
-			time.Sleep(e.GetRetryAfter())
-			continue
 		case *github.ErrorResponse:
 			if e.Response.StatusCode == http.StatusNotFound {
 				log.Println(err)
@@ -218,12 +203,6 @@ func ListComments(ctx context.Context, gh *github.Client, owner, repo string, nu
 	for {
 		comments, resp, err := gh.Issues.ListComments(ctx, owner, repo, number, opt)
 		switch e := err.(type) {
-		case *github.RateLimitError:
-			time.Sleep(time.Until(e.Rate.Reset.Add(skew)))
-			continue
-		case *github.AbuseRateLimitError:
-			time.Sleep(e.GetRetryAfter())
-			continue
 		case *github.ErrorResponse:
 			if e.Response.StatusCode == http.StatusNotFound {
 				log.Println(err)
@@ -413,4 +392,186 @@ func ListTags2(ctx context.Context, gh *github.Client, owner, repo string) ([]*g
 		opt.Page = resp.NextPage
 	}
 	return result, nil
+}
+
+type rateLimitTransport struct {
+	base http.RoundTripper
+}
+
+func (t *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.GetBody == nil {
+		if f, ok := req.Body.(*os.File); ok {
+			name := f.Name()
+			req.GetBody = func() (io.ReadCloser, error) {
+				return os.Open(name)
+			}
+		}
+	}
+
+	canRetryBody := req.Body == nil || req.Body == http.NoBody || req.GetBody != nil
+
+	for attempt := 0; ; attempt++ {
+		currReq := req
+		if attempt > 0 {
+			currReq = req.Clone(req.Context())
+			if req.GetBody != nil {
+				body, err := req.GetBody()
+				if err != nil {
+					return nil, err
+				}
+				currReq.Body = body
+			}
+		}
+
+		resp, err := t.base.RoundTrip(currReq)
+		if err != nil {
+			return nil, err
+		}
+		if resp == nil {
+			return resp, nil
+		}
+
+		kind := classifyResponse(resp)
+		if kind == kindNone {
+			return resp, nil
+		}
+		if attempt >= maxRateLimitRetryAttempts {
+			log.Printf("GitHub API still failing after %d retries (status=%d); giving up", attempt, resp.StatusCode)
+			return resp, nil
+		}
+		if !canRetryBody {
+			return resp, nil
+		}
+
+		delay, source := retryDelay(resp, kind, attempt)
+		logRetry(resp, kind, delay, source)
+
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-req.Context().Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return nil, req.Context().Err()
+		case <-timer.C:
+		}
+	}
+}
+
+type responseKind int
+
+const (
+	kindNone responseKind = iota
+	kindPrimaryRateLimit
+	kindSecondaryRateLimit
+	kindServerError
+)
+
+// classifyResponse decides whether a response is retryable per
+// https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api.
+//
+// A 403/429 is only treated as a rate limit when GitHub provides a Retry-After
+// header or X-RateLimit-Remaining=0. Bare 403s are permission errors and
+// retrying them is wasteful.
+func classifyResponse(resp *http.Response) responseKind {
+	switch resp.StatusCode {
+	case http.StatusForbidden, http.StatusTooManyRequests:
+		hasRetryAfter := resp.Header.Get("Retry-After") != ""
+		exhausted := resp.Header.Get("X-RateLimit-Remaining") == "0"
+		switch {
+		case exhausted:
+			return kindPrimaryRateLimit
+		case hasRetryAfter:
+			return kindSecondaryRateLimit
+		default:
+			return kindNone
+		}
+	case http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return kindServerError
+	default:
+		return kindNone
+	}
+}
+
+func retryDelay(resp *http.Response, kind responseKind, attempt int) (time.Duration, string) {
+	if d := parseRetryAfter(resp.Header.Get("Retry-After")); d > 0 {
+		return d, "Retry-After header"
+	}
+
+	switch kind {
+	case kindPrimaryRateLimit:
+		if reset := parseUnixTime(resp.Header.Get("X-RateLimit-Reset")); !reset.IsZero() {
+			return max(time.Until(reset)+time.Second, time.Second), "X-RateLimit-Reset header"
+		}
+		return secondaryBackoff(attempt), "rate-limit backoff (no reset header)"
+	case kindSecondaryRateLimit:
+		return secondaryBackoff(attempt), "secondary rate-limit backoff"
+	case kindServerError:
+		return serverErrorBackoff(attempt), "exponential backoff after server error"
+	}
+	return time.Second, ""
+}
+
+// secondaryBackoff implements the GitHub-recommended "at least 1 minute,
+// increase exponentially" backoff for secondary rate limits.
+func secondaryBackoff(attempt int) time.Duration {
+	d := time.Duration(float64(defaultSecondaryRetryDelay) * math.Pow(2, float64(attempt)))
+	return max(min(d, maxSecondaryRetryDelay), defaultSecondaryRetryDelay)
+}
+
+func serverErrorBackoff(attempt int) time.Duration {
+	d := time.Duration(float64(defaultServerErrorDelay) * math.Pow(2, float64(attempt)))
+	return max(min(d, maxSecondaryRetryDelay), time.Second)
+}
+
+func logRetry(resp *http.Response, kind responseKind, delay time.Duration, source string) {
+	rounded := delay.Round(time.Second)
+	resource := resp.Header.Get("X-RateLimit-Resource")
+	suffix := ""
+	if resource != "" {
+		suffix = " resource=" + resource
+	}
+
+	switch kind {
+	case kindPrimaryRateLimit:
+		log.Printf("GitHub API primary rate limit hit (%d%s); waiting %s before retry (%s)", resp.StatusCode, suffix, rounded, source)
+	case kindSecondaryRateLimit:
+		log.Printf("GitHub API secondary rate limit hit (%d%s); waiting %s before retry (%s)", resp.StatusCode, suffix, rounded, source)
+	case kindServerError:
+		log.Printf("GitHub API server error (%d); waiting %s before retry (%s)", resp.StatusCode, rounded, source)
+	}
+}
+
+func parseRetryAfter(value string) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds < 1 {
+			seconds = 1
+		}
+		return time.Duration(seconds) * time.Second
+	}
+	if ts, err := http.ParseTime(value); err == nil {
+		return max(time.Until(ts), time.Second)
+	}
+	return 0
+}
+
+func parseUnixTime(value string) time.Time {
+	if value == "" {
+		return time.Time{}
+	}
+	sec, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	return time.Unix(sec, 0).UTC()
 }

--- a/lib/github.go
+++ b/lib/github.go
@@ -45,7 +45,7 @@ const (
 func NewGitHubClient() *github.Client {
 	token, found := os.LookupEnv(api.GitHubTokenKey)
 	if !found {
-		panic(api.GitHubTokenKey + " env var is not set")
+		log.Fatalln(api.GitHubTokenKey + " env var is not set")
 	}
 
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
@@ -68,16 +68,10 @@ func ListLabelsByIssue(ctx context.Context, gh *github.Client, owner, repo strin
 	result := sets.New[string]()
 	for {
 		labels, resp, err := gh.Issues.ListLabelsByIssue(ctx, owner, repo, number, opt)
-		switch e := err.(type) {
-		case *github.ErrorResponse:
-			if e.Response.StatusCode == http.StatusNotFound {
+		if err != nil {
+			if ge, ok := err.(*github.ErrorResponse); ok && ge.Response.StatusCode == http.StatusNotFound {
 				log.Println(err)
-				break
 			} else {
-				return nil, err
-			}
-		default:
-			if e != nil {
 				return nil, err
 			}
 		}
@@ -101,16 +95,10 @@ func ListReleases(ctx context.Context, gh *github.Client, owner, repo string) ([
 	var result []*github.RepositoryRelease
 	for {
 		releases, resp, err := gh.Repositories.ListReleases(ctx, owner, repo, opt)
-		switch e := err.(type) {
-		case *github.ErrorResponse:
-			if e.Response.StatusCode == http.StatusNotFound {
+		if err != nil {
+			if ge, ok := err.(*github.ErrorResponse); ok && ge.Response.StatusCode == http.StatusNotFound {
 				log.Println(err)
-				break
 			} else {
-				return nil, err
-			}
-		default:
-			if e != nil {
 				return nil, err
 			}
 		}
@@ -132,16 +120,10 @@ func ListReviews(ctx context.Context, gh *github.Client, owner, repo string, num
 	var result []*github.PullRequestReview
 	for {
 		reviews, resp, err := gh.PullRequests.ListReviews(ctx, owner, repo, number, opt)
-		switch e := err.(type) {
-		case *github.ErrorResponse:
-			if e.Response.StatusCode == http.StatusNotFound {
+		if err != nil {
+			if ge, ok := err.(*github.ErrorResponse); ok && ge.Response.StatusCode == http.StatusNotFound {
 				log.Println(err)
-				break
 			} else {
-				return nil, err
-			}
-		default:
-			if e != nil {
 				return nil, err
 			}
 		}
@@ -167,16 +149,10 @@ func ListPullRequestComment(ctx context.Context, gh *github.Client, owner, repo 
 	var result []*github.PullRequestComment
 	for {
 		comments, resp, err := gh.PullRequests.ListComments(ctx, owner, repo, number, opt)
-		switch e := err.(type) {
-		case *github.ErrorResponse:
-			if e.Response.StatusCode == http.StatusNotFound {
+		if err != nil {
+			if ge, ok := err.(*github.ErrorResponse); ok && ge.Response.StatusCode == http.StatusNotFound {
 				log.Println(err)
-				break
 			} else {
-				return nil, err
-			}
-		default:
-			if e != nil {
 				return nil, err
 			}
 		}
@@ -202,16 +178,10 @@ func ListComments(ctx context.Context, gh *github.Client, owner, repo string, nu
 	var result []*github.IssueComment
 	for {
 		comments, resp, err := gh.Issues.ListComments(ctx, owner, repo, number, opt)
-		switch e := err.(type) {
-		case *github.ErrorResponse:
-			if e.Response.StatusCode == http.StatusNotFound {
+		if err != nil {
+			if ge, ok := err.(*github.ErrorResponse); ok && ge.Response.StatusCode == http.StatusNotFound {
 				log.Println(err)
-				break
 			} else {
-				return nil, err
-			}
-		default:
-			if e != nil {
 				return nil, err
 			}
 		}

--- a/lib/gomod.go
+++ b/lib/gomod.go
@@ -47,8 +47,12 @@ func IsPublicGitRepo(repoURL string) bool {
 		repoURL = "https://" + repoURL
 	}
 
-	_, err := http.Get(repoURL)
-	return err == nil
+	resp, err := http.Get(repoURL)
+	if err != nil {
+		return false
+	}
+	_ = resp.Body.Close()
+	return true
 }
 
 func DetectVCSRoot(repoURL string) (string, error) {
@@ -68,6 +72,7 @@ func DetectVCSRoot(repoURL string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer res.Body.Close()
 	data := new(MetaData)
 
 	err = metabolize.Metabolize(res.Body, data)


### PR DESCRIPTION
## Summary
Wraps the oauth2 HTTP client in `NewGitHubClient` with the same rate-limit-aware transport that landed in [appscodelabs/gh-tools#55](https://github.com/appscodelabs/gh-tools/pull/55), aligning with [GitHub's REST rate-limit guidance](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api):

- Distinguish **primary** (`X-RateLimit-Remaining=0`) vs **secondary** (`Retry-After`) rate limits from plain `403` permission errors. Bare 403s are no longer retried — those are auth/permission failures, not rate limits.
- Log `X-RateLimit-Resource` so the affected bucket (core, search, graphql, integration_manifest) is visible.
- Floor the secondary backoff at 1 minute per the documented minimum, and honor `Retry-After` on 5xx responses too.
- Retry transient `502`/`503`/`504` alongside `500`.
- Log when the retry budget is exhausted instead of silently returning the failed response.

Also drops the redundant `*github.RateLimitError` / `*github.AbuseRateLimitError` cases from `ListLabelsByIssue`, `ListReleases`, `ListReviews`, `ListPullRequestComment`, and `ListComments` — the transport handles those responses before the error surfaces. The `ErrorResponse` 404 handling is kept.

## Test plan
- [x] `go build -mod=vendor ./...`
- [x] `go vet -mod=vendor ./...`
- [ ] Run a release flow that previously hit rate limits and confirm logs show primary/secondary classification + resource bucket

🤖 Generated with [Claude Code](https://claude.com/claude-code)