### PR TITLE
Fix correctness bugs across lib/, cmds/, and api/

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -323,8 +323,17 @@ func (chlog *Changelog) Sort() {
 	sort.Slice(chlog.Projects, func(i, j int) bool { return chlog.Projects[i].URL < chlog.Projects[j].URL })
 	for idx, projects := range chlog.Projects {
 		sort.Slice(projects.Releases, func(i, j int) bool {
-			vi, _ := semver.NewVersion(projects.Releases[i].Tag)
-			vj, _ := semver.NewVersion(projects.Releases[j].Tag)
+			vi, errI := semver.NewVersion(projects.Releases[i].Tag)
+			vj, errJ := semver.NewVersion(projects.Releases[j].Tag)
+			// Sort unparseable tags to the end and fall back to string compare.
+			switch {
+			case errI != nil && errJ != nil:
+				return projects.Releases[i].Tag < projects.Releases[j].Tag
+			case errI != nil:
+				return false
+			case errJ != nil:
+				return true
+			}
 			return semvers.CompareVersions(vi, vj)
 		})
 		chlog.Projects[idx] = projects

--- a/cmds/kubedb_record_legacy_releases.go
+++ b/cmds/kubedb_record_legacy_releases.go
@@ -65,7 +65,10 @@ func NewCmdKubeDBRecordLegacyReleases() *cobra.Command {
 }
 
 func CreateKubeDBReleaseTable() api.ReleaseTable {
-	gh := lib.NewGitHubClient()
+	gh, err := lib.NewGitHubClient()
+	if err != nil {
+		panic(err)
+	}
 	releases, err := lib.ListReleases(context.TODO(), gh, "kubedb", "cli")
 	if err != nil {
 		panic(err)

--- a/cmds/release_readme.go
+++ b/cmds/release_readme.go
@@ -52,11 +52,12 @@ func GenerateTable() api.ReleaseTable {
 
 	legacyfilename := filepath.Join(changelogRoot, "legacy_releases.json")
 	data, err := os.ReadFile(legacyfilename)
-	if !os.IsNotExist(err) {
-		err = json.Unmarshal(data, &table)
-		if err != nil {
+	if err == nil {
+		if err := json.Unmarshal(data, &table); err != nil {
 			panic(err)
 		}
+	} else if !os.IsNotExist(err) {
+		panic(err)
 	}
 
 	entries, err := os.ReadDir(changelogRoot)

--- a/cmds/release_run.go
+++ b/cmds/release_run.go
@@ -18,6 +18,7 @@ package cmds
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"maps"
 	"os"
@@ -461,6 +462,34 @@ func runAutomaton() {
 	}
 }
 
+// gitCloneWithToken runs `git clone` against a plain HTTPS URL, passing the
+// credentials via `--config http.<host>.extraheader=...` instead of embedding
+// them in the URL. This keeps the token out of the session log AND out of the
+// cloned repo's `origin` URL in .git/config. The extraheader config is
+// persisted into the new repo's local config so subsequent fetch/push against
+// `origin` (same host) authenticate automatically.
+func gitCloneWithToken(sh *shell.Session, repoURL string, extraArgs ...string) error {
+	cloneURL := fmt.Sprintf("https://%s.git", repoURL)
+	creds := base64.StdEncoding.EncodeToString([]byte(os.Getenv(api.GitHubUserKey) + ":" + os.Getenv(api.GitHubTokenKey)))
+	authConfig := "http.https://github.com/.extraheader=AUTHORIZATION: basic " + creds
+
+	args := make([]any, 0, 3+len(extraArgs)+1)
+	args = append(args, "clone", "--config", authConfig)
+	for _, a := range extraArgs {
+		args = append(args, a)
+	}
+	args = append(args, cloneURL)
+
+	prev := sh.ShowCMD
+	sh.ShowCMD = false
+	if prev {
+		fmt.Printf("$ git clone %s %s\n", strings.Join(extraArgs, " "), cloneURL)
+	}
+	err := sh.Command("git", args...).Run()
+	sh.ShowCMD = prev
+	return err
+}
+
 func UpdateChartIndex(gh *github.Client, sh *shell.Session, repoURL string) error {
 	// pushd, popd
 	wdOrig := sh.Getwd()
@@ -478,14 +507,12 @@ func UpdateChartIndex(gh *github.Client, sh *shell.Session, repoURL string) erro
 	if !lib.Exists(filepath.Join(wdCur, repo)) {
 		sh.SetDir(wdCur)
 
-		err = sh.Command("git",
-			"clone",
+		err = gitCloneWithToken(sh, repoURL,
 			// "--no-tags", //TODO: ok?
 			"--recurse-submodules",
 			//"--depth=1",
 			//"--no-single-branch",
-			fmt.Sprintf("https://%s:%s@%s.git", os.Getenv(api.GitHubUserKey), os.Getenv(api.GitHubTokenKey), repoURL),
-		).Run()
+		)
 		if err != nil {
 			return err
 		}
@@ -539,14 +566,12 @@ func PrepareProject(gh *github.Client, sh *shell.Session, releaseTracker, repoUR
 	if !lib.Exists(filepath.Join(wdCur, repo)) {
 		sh.SetDir(wdCur)
 
-		err = sh.Command("git",
-			"clone",
+		err = gitCloneWithToken(sh, repoURL,
 			// "--no-tags", //TODO: ok?
 			"--recurse-submodules",
 			//"--depth=1",
 			//"--no-single-branch",
-			fmt.Sprintf("https://%s:%s@%s.git", os.Getenv(api.GitHubUserKey), os.Getenv(api.GitHubTokenKey), repoURL),
-		).Run()
+		)
 		if err != nil {
 			return err
 		}
@@ -789,14 +814,12 @@ func ReleaseProject(sh *shell.Session, releaseTracker, repoURL string, project a
 	if !lib.Exists(filepath.Join(wdCur, repo)) {
 		sh.SetDir(wdCur)
 
-		err = sh.Command("git",
-			"clone",
+		err = gitCloneWithToken(sh, repoURL,
 			// "--no-tags", //TODO: ok?
 			"--recurse-submodules",
 			//"--depth=1",
 			//"--no-single-branch",
-			fmt.Sprintf("https://%s:%s@%s.git", os.Getenv(api.GitHubUserKey), os.Getenv(api.GitHubTokenKey), repoURL),
-		).Run()
+		)
 		if err != nil {
 			return err
 		}
@@ -1098,14 +1121,12 @@ func PrepareExternalProject(gh *github.Client, sh *shell.Session, releaseTracker
 	if !lib.Exists(filepath.Join(wdCur, repo)) {
 		sh.SetDir(wdCur)
 
-		err = sh.Command("git",
-			"clone",
+		err = gitCloneWithToken(sh, repoURL,
 			"--no-tags",
 			"--recurse-submodules",
 			"--depth=1",
 			"--no-single-branch",
-			fmt.Sprintf("https://%s:%s@%s.git", os.Getenv(api.GitHubUserKey), os.Getenv(api.GitHubTokenKey), repoURL),
-		).Run()
+		)
 		if err != nil {
 			return err
 		}

--- a/cmds/release_run.go
+++ b/cmds/release_run.go
@@ -149,7 +149,10 @@ func runAutomaton() {
 
 	releaseOwner, releaseRepo, releasePR := lib.ParsePullRequestURL(releaseTracker)
 
-	gh := lib.NewGitHubClient()
+	gh, err := lib.NewGitHubClient()
+	if err != nil {
+		panic(err)
+	}
 	pr, _, err := gh.PullRequests.Get(context.TODO(), releaseOwner, releaseRepo, releasePR)
 	if err != nil {
 		panic(err)

--- a/cmds/release_run.go
+++ b/cmds/release_run.go
@@ -450,7 +450,7 @@ func runAutomaton() {
 			// Do not want external projects to report back, so releaseTracker is not set.
 			err = PrepareExternalProject(gh, sh, "", repoURL, project)
 			if err != nil {
-				break
+				panic(err)
 			}
 		}
 	}

--- a/cmds/release_run.go
+++ b/cmds/release_run.go
@@ -165,7 +165,11 @@ func runAutomaton() {
 		fmt.Println("Release tracker pr is not open")
 		return
 	}
-	if !lib.PRApproved(gh, releaseOwner, releaseRepo, releasePR) {
+	approved, err := lib.PRApproved(gh, releaseOwner, releaseRepo, releasePR)
+	if err != nil {
+		panic(err)
+	}
+	if !approved {
 		fmt.Println("PR must be approved to continue")
 		return
 	}

--- a/cmds/update_assets.go
+++ b/cmds/update_assets.go
@@ -238,15 +238,18 @@ func sortProductVersions(versions []saapi.ProductVersion) ([]saapi.ProductVersio
 	sort.Slice(data, func(i, j int) bool {
 		return !semvers.CompareVersions(semver.MustParse(data[i].Version), semver.MustParse(data[j].Version))
 	})
-	latestVersion := data[0].Version
-	for i := range data {
-		v := semver.MustParse(data[i].Version)
-		if !data[i].Show || v.Prerelease() != "" {
-			continue
+	var latestVersion string
+	if len(data) > 0 {
+		latestVersion = data[0].Version
+		for i := range data {
+			v := semver.MustParse(data[i].Version)
+			if !data[i].Show || v.Prerelease() != "" {
+				continue
+			}
+			// Use the latest non pre-release version
+			latestVersion = data[i].Version
+			break
 		}
-		// Use the latest non pre-release version
-		latestVersion = data[i].Version
-		break
 	}
 
 	// inject to the top

--- a/cmds/voyager_record_legacy_releases.go
+++ b/cmds/voyager_record_legacy_releases.go
@@ -71,7 +71,10 @@ func CreateVoyagerReleaseTable() (*api.ReleaseTable, error) {
 	owner := "voyagermesh"
 	repo := "voyager"
 
-	gh := lib.NewGitHubClient()
+	gh, err := lib.NewGitHubClient()
+	if err != nil {
+		return nil, err
+	}
 	releases, err := lib.ListReleases(context.TODO(), gh, owner, repo)
 	if err != nil {
 		return nil, err

--- a/lib/git.go
+++ b/lib/git.go
@@ -80,7 +80,11 @@ func GetRemoteTag(sh *shell.Session, tag string) string {
 	if err != nil {
 		return ""
 	}
-	return strings.Fields(string(data))[0]
+	fields := strings.Fields(string(data))
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
 }
 
 func GetRemoteCommitHash(sh *shell.Session, url, tag string) string {
@@ -95,7 +99,11 @@ func GetRemoteCommitHash(sh *shell.Session, url, tag string) string {
 	if err != nil {
 		return ""
 	}
-	return strings.Fields(string(data))[0]
+	fields := strings.Fields(string(data))
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
 }
 
 // IsTagged checks if the current commit is tagged.
@@ -127,6 +135,9 @@ func FirstCommit(sh *shell.Session) string {
 		panic(err)
 	}
 	commits := strings.Fields(string(data))
+	if len(commits) == 0 {
+		return ""
+	}
 	return commits[len(commits)-1]
 }
 
@@ -137,6 +148,9 @@ func LastCommitSHA(sh *shell.Session) string {
 		panic(err)
 	}
 	commits := strings.Fields(string(data))
+	if len(commits) == 0 {
+		return ""
+	}
 	return commits[0]
 }
 

--- a/lib/github.go
+++ b/lib/github.go
@@ -196,22 +196,22 @@ func ListComments(ctx context.Context, gh *github.Client, owner, repo string, nu
 }
 
 // https://developer.github.com/v3/pulls/reviews/#create-a-review-for-a-pull-request
-func PRApproved(gh *github.Client, owner string, repo string, prNumber int) bool {
+func PRApproved(gh *github.Client, owner string, repo string, prNumber int) (bool, error) {
 	reviews, err := ListReviews(context.TODO(), gh, owner, repo, prNumber)
 	if err != nil {
-		panic(err)
+		return false, err
 	}
 	for _, review := range reviews {
 		if review.GetState() == "REQUEST_CHANGES" {
-			return false
+			return false, nil
 		}
 	}
 	for _, review := range reviews {
 		if review.GetState() == "APPROVED" {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 func CreatePR(gh *github.Client, owner string, repo string, req *github.NewPullRequest, labels ...string) (*github.PullRequest, error) {

--- a/lib/github.go
+++ b/lib/github.go
@@ -42,10 +42,10 @@ const (
 	maxRateLimitRetryAttempts  = 8
 )
 
-func NewGitHubClient() *github.Client {
+func NewGitHubClient() (*github.Client, error) {
 	token, found := os.LookupEnv(api.GitHubTokenKey)
 	if !found {
-		log.Fatalln(api.GitHubTokenKey + " env var is not set")
+		return nil, fmt.Errorf("%s env var is not set", api.GitHubTokenKey)
 	}
 
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
@@ -57,7 +57,7 @@ func NewGitHubClient() *github.Client {
 	}
 	tc.Transport = &rateLimitTransport{base: baseTransport}
 
-	return github.NewClient(tc)
+	return github.NewClient(tc), nil
 }
 
 func ListLabelsByIssue(ctx context.Context, gh *github.Client, owner, repo string, number int) (sets.Set[string], error) {

--- a/lib/github.go
+++ b/lib/github.go
@@ -351,11 +351,11 @@ func ListTags2(ctx context.Context, gh *github.Client, owner, repo string) ([]*g
 
 	var result []*github.RepositoryTag
 	for {
-		reviews, resp, err := gh.Repositories.ListTags(ctx, owner, repo, opt)
+		tags, resp, err := gh.Repositories.ListTags(ctx, owner, repo, opt)
 		if err != nil {
-			break
+			return nil, err
 		}
-		result = append(result, reviews...)
+		result = append(result, tags...)
 		if resp.NextPage == 0 {
 			break
 		}

--- a/lib/gomod.go
+++ b/lib/gomod.go
@@ -22,9 +22,12 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/keighl/metabolize"
 )
+
+var httpClient = &http.Client{Timeout: 30 * time.Second}
 
 type GoImport struct {
 	RepoRoot string
@@ -47,12 +50,12 @@ func IsPublicGitRepo(repoURL string) bool {
 		repoURL = "https://" + repoURL
 	}
 
-	resp, err := http.Get(repoURL)
+	resp, err := httpClient.Get(repoURL)
 	if err != nil {
 		return false
 	}
 	_ = resp.Body.Close()
-	return true
+	return resp.StatusCode < 400
 }
 
 func DetectVCSRoot(repoURL string) (string, error) {
@@ -68,7 +71,7 @@ func DetectVCSRoot(repoURL string) (string, error) {
 	qRepo.Set("go-get", "1")
 	uRepo.RawQuery = qRepo.Encode()
 
-	res, err := http.Get(uRepo.String())
+	res, err := httpClient.Get(uRepo.String())
 	if err != nil {
 		return "", err
 	}

--- a/lib/gomod.go
+++ b/lib/gomod.go
@@ -75,7 +75,7 @@ func DetectVCSRoot(repoURL string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 	data := new(MetaData)
 
 	err = metabolize.Metabolize(res.Body, data)

--- a/lib/gomod_test.go
+++ b/lib/gomod_test.go
@@ -30,9 +30,13 @@ func TestDetectVCSRoot(t *testing.T) {
 	// res, _ := http.Get("https://k8s.io/api?go-get=1")
 	// "https://github.com/cloudevents/sdk-go/blob/master/samples/kafka?go-get=1"
 
+	if testing.Short() {
+		t.Skip("skipping network-dependent test in short mode")
+	}
+
 	r, err := DetectVCSRoot("stash.appscode.dev/cli")
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	fmt.Println(r)
 }

--- a/main_extras.go
+++ b/main_extras.go
@@ -88,11 +88,12 @@ func main_CreateKubeDBReleaseTable() {
 }
 
 func main_RemoveLabel() {
-	gh := lib.NewGitHubClient()
+	gh, err := lib.NewGitHubClient()
+	if err != nil {
+		panic(err)
+	}
 	u := "https://github.com/appscodelabs/release-automaton-demo/pull/1"
 	fmt.Println(u)
-
-	var err error
 
 	_, _, err = gh.Issues.AddLabelsToIssue(context.TODO(), "appscodelabs", "release-automaton-demo", 1, []string{
 		"xyz",
@@ -215,7 +216,10 @@ func main_CreatePR() {
 	owner := "tamalsaha"
 	repo := "gh-release-automation-testing"
 
-	gh := lib.NewGitHubClient()
+	gh, err := lib.NewGitHubClient()
+	if err != nil {
+		panic(err)
+	}
 
 	pr, err := lib.CreatePR(gh, owner, repo, &github.NewPullRequest{
 		Title:               github.String("Test pr api"),


### PR DESCRIPTION
## Summary

Targeted bugs & correctness review of the Go code in this repo. Eleven low-risk fixes; no public function signatures change in a way that affects release behavior.

- `cmds/update_assets.go` — guard `data[0].Version` access in `sortProductVersions`; previously panicked when only a `master` entry was present and got filtered out
- `cmds/release_readme.go` — `!os.IsNotExist(err)` was true for ALL non-ENOENT errors, then `json.Unmarshal` ran on whatever (possibly empty) `data` came back. Reordered to: read OK → unmarshal; ENOENT → skip; any other err → panic
- `api/types.go` — `Changelog.Sort` dropped parse errors and passed `nil *semver.Version` to `semvers.CompareVersions`, which then `nil.SetPrerelease("")` panics. Unparseable tags now sort to the end with a string-compare fallback
- `lib/git.go` — `FirstCommit`, `LastCommitSHA`, `GetRemoteTag` now length-guard `strings.Fields` output before indexing
- `lib/gomod.go` — `IsPublicGitRepo` had no timeout (used `http.DefaultClient`) and returned `true` for 4xx/5xx responses. Switched to a shared client with a 30s timeout and a status-code check; `DetectVCSRoot` reuses it
- `lib/gomod_test.go` — added `testing.Short()` skip and replaced `panic(err)` with `t.Fatal(err)`
- `cmds/release_run.go:487, 548, 798, 1107` — stop leaking GitHub token to CI logs from `git clone`. All four sites built `https://<user>:<token>@github.com/...` and ran it through a session with `sh.ShowCMD = true`, echoing the token into logs and persisting it into each repo's `origin` URL. Routed through a new `gitCloneWithToken` helper that passes credentials via `--config http.https://github.com/.extraheader=AUTHORIZATION: basic <base64>` with a plain clone URL, disables `ShowCMD` around the call, and prints a sanitized echo. Git persists the extraheader into the cloned repo's local config so subsequent `git fetch origin` / `git push origin` keep working.
- `lib/github.go:45` — `NewGitHubClient` called `log.Fatalln` on missing `GITHUB_TOKEN`, which `os.Exit(1)`s past any deferred cleanup in callers and makes the function untestable. Changed signature to `(*github.Client, error)` and updated all five callers (`main_extras.go` x2, `cmds/release_run.go`, `cmds/voyager_record_legacy_releases.go`, `cmds/kubedb_record_legacy_releases.go`) to match the surrounding error-handling style (`panic(err)` or `return nil, err`).
- `lib/github.go:347-365` — `ListTags2` did `if err != nil { break }` inside the pagination loop and then `return result, nil`. Any network/auth/rate-limit failure produced a partial-or-empty result with a nil error — callers couldn't detect it. Now returns `nil, err` on failure.
- `lib/github.go:199` — `PRApproved` called `panic(err)` on any error from `ListReviews`, so a transient GitHub failure crashed the release automaton. Changed signature to `(bool, error)` and updated the lone caller in `cmds/release_run.go:168` to propagate via `panic(err)` (same observable behavior on failure, but now behind a real boundary).
- `cmds/release_run.go:443-447` — looped over `release.ExternalProjects`, called `PrepareExternalProject`, and on error just `break`ed out of the loop. Execution then fell through to the block that appends `api.Done` to comments and posts it — falsely signalling success after a real failure, and skipping any remaining external projects. Changed to `panic(err)` to match the established pattern at the other `PrepareExternalProject` callsite (panic at line 378).

## Test plan

- [x] \`GOFLAGS="-mod=vendor" go build ./...\` — clean
- [x] \`GOFLAGS="-mod=vendor" go vet ./...\` — clean
- [x] \`GOFLAGS="-mod=vendor" go test -short ./...\` — pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)