### PR TITLE
Grant contents:write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1


### PR DESCRIPTION
## Summary
- The Release job in `.github/workflows/release.yml` was failing with HTTP 403 when `softprops/action-gh-release` attempted to create the GitHub release for tag `v0.0.44` (see [run 26240954034](https://github.com/appscodelabs/release-automaton/actions/runs/26240954034/job/77226836583)).
- The default `GITHUB_TOKEN` does not have write access to repository contents, which is required to create a release.
- Added an explicit `permissions: contents: write` block to the `build` job so the token can create the release.

## Test plan
- [ ] Re-push tag `v0.0.44` (or trigger via `workflow_dispatch`) after merging and confirm the Release step succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)