### PR TITLE
Remove FerretDB support

### DIFF
--- a/cmds/kubedb_create_release.go
+++ b/cmds/kubedb_create_release.go
@@ -72,7 +72,6 @@ func CreateKubeDBReleaseFile() api.Release {
 				"github.com/kubedb/clickhouse":                 api.Project{Tag: TagP("v0.20.0", prerelease)},
 				"github.com/kubedb/documentdb":                 api.Project{Tag: TagP("v0.2.0", prerelease)},
 				"github.com/kubedb/druid":                      api.Project{Tag: TagP("v0.20.0", prerelease)},
-				"github.com/kubedb/ferretdb":                   api.Project{Tag: TagP("v0.20.0", prerelease)},
 				"github.com/kubedb/pgpool":                     api.Project{Tag: TagP("v0.20.0", prerelease)},
 				"github.com/kubedb/rabbitmq":                   api.Project{Tag: TagP("v0.20.0", prerelease)},
 				"github.com/kubedb/singlestore":                api.Project{Tag: TagP("v0.20.0", prerelease)},


### PR DESCRIPTION
## Summary
- Drop `github.com/kubedb/ferretdb` from the KubeDB release project list in `cmds/kubedb_create_release.go`.

## Test plan
- [ ] CI builds the binary.