### PR TITLE
Skip set-operator-version when kubedb docs are hidden

### DIFF
--- a/cmds/ace_create_release.go
+++ b/cmds/ace_create_release.go
@@ -54,10 +54,6 @@ func CreateAceReleaseFile() api.Release {
 	// hideDocs hides this release's docs from the website. When set, the release
 	// is not advertised as the website's version either.
 	hideDocs := false
-	updateAssetsFlags := ""
-	if hideDocs {
-		updateAssetsFlags = "--hide "
-	}
 	return api.Release{
 		ProductLine: "ACE",
 		Release:     releaseNumber,
@@ -202,7 +198,7 @@ func CreateAceReleaseFile() api.Release {
 				// Must come before docs repo, so we can generate the docs_changelog.md
 				"github.com/appscode/static-assets": api.Project{
 					Commands: []string{
-						fmt.Sprintf("release-automaton update-assets %s--release-file=${SCRIPT_ROOT}/releases/${RELEASE}/release.json --workspace=${WORKSPACE}", updateAssetsFlags),
+						UpdateAssetsCmd(hideDocs),
 					},
 					Changelog: api.StandaloneWebsiteChangelog,
 				},

--- a/cmds/ace_create_release.go
+++ b/cmds/ace_create_release.go
@@ -51,6 +51,13 @@ func NewCmdAceCreateRelease() *cobra.Command {
 func CreateAceReleaseFile() api.Release {
 	prerelease := ""
 	releaseNumber := "v2026.7.10" + prerelease
+	// hideDocs hides this release's docs from the website. When set, the release
+	// is not advertised as the website's version either.
+	hideDocs := false
+	updateAssetsFlags := ""
+	if hideDocs {
+		updateAssetsFlags = "--hide "
+	}
 	return api.Release{
 		ProductLine: "ACE",
 		Release:     releaseNumber,
@@ -195,7 +202,7 @@ func CreateAceReleaseFile() api.Release {
 				// Must come before docs repo, so we can generate the docs_changelog.md
 				"github.com/appscode/static-assets": api.Project{
 					Commands: []string{
-						"release-automaton update-assets --release-file=${SCRIPT_ROOT}/releases/${RELEASE}/release.json --workspace=${WORKSPACE}",
+						fmt.Sprintf("release-automaton update-assets %s--release-file=${SCRIPT_ROOT}/releases/${RELEASE}/release.json --workspace=${WORKSPACE}", updateAssetsFlags),
 					},
 					Changelog: api.StandaloneWebsiteChangelog,
 				},
@@ -219,7 +226,7 @@ func CreateAceReleaseFile() api.Release {
 							"make set-assets-repo ASSETS_REPO_URL=https://github.com/appscode/static-assets",
 							"make assets docs-platform",
 						},
-						semvers.IsPublicRelease(releaseNumber),
+						!hideDocs && semvers.IsPublicRelease(releaseNumber),
 						"make set-platform-version VERSION=${RELEASE}",
 					),
 					Changelog: api.SkipChangelog,

--- a/cmds/kubedb_create_release.go
+++ b/cmds/kubedb_create_release.go
@@ -51,6 +51,13 @@ func NewCmdKubeDBCreateRelease() *cobra.Command {
 func CreateKubeDBReleaseFile() api.Release {
 	prerelease := ""
 	releaseNumber := "v2026.7.10" + prerelease
+	// hideDocs hides this release's docs from the website. When set, the release
+	// is not advertised as the website's operator version either.
+	hideDocs := true
+	updateAssetsFlags := ""
+	if hideDocs {
+		updateAssetsFlags = "--hide "
+	}
 	return api.Release{
 		ProductLine:       "KubeDB",
 		Release:           releaseNumber,
@@ -348,7 +355,7 @@ func CreateKubeDBReleaseFile() api.Release {
 					Commands: []string{
 						"curl -fsSL https://github.com/kubedb/installer/raw/${RELEASE}/catalog/kubedb/active_versions.json -o /tmp/kubedb-active-versions.json",
 						"release-automaton kubedb update-example-versions /tmp/kubedb-active-versions.json --workspace=${WORKSPACE}",
-						"release-automaton update-assets --hide --release-file=${SCRIPT_ROOT}/releases/${RELEASE}/release.json --workspace=${WORKSPACE}",
+						fmt.Sprintf("release-automaton update-assets %s--release-file=${SCRIPT_ROOT}/releases/${RELEASE}/release.json --workspace=${WORKSPACE}", updateAssetsFlags),
 					},
 					Changelog: api.StandaloneWebsiteChangelog,
 				},
@@ -372,7 +379,7 @@ func CreateKubeDBReleaseFile() api.Release {
 							"make set-assets-repo ASSETS_REPO_URL=https://github.com/appscode/static-assets",
 							"make docs",
 						},
-						semvers.IsPublicRelease(releaseNumber),
+						!hideDocs && semvers.IsPublicRelease(releaseNumber),
 						"make set-operator-version VERSION=${TAG}",
 					),
 					Changelog: api.SkipChangelog,

--- a/cmds/kubedb_create_release.go
+++ b/cmds/kubedb_create_release.go
@@ -54,10 +54,6 @@ func CreateKubeDBReleaseFile() api.Release {
 	// hideDocs hides this release's docs from the website. When set, the release
 	// is not advertised as the website's operator version either.
 	hideDocs := true
-	updateAssetsFlags := ""
-	if hideDocs {
-		updateAssetsFlags = "--hide "
-	}
 	return api.Release{
 		ProductLine:       "KubeDB",
 		Release:           releaseNumber,
@@ -355,7 +351,7 @@ func CreateKubeDBReleaseFile() api.Release {
 					Commands: []string{
 						"curl -fsSL https://github.com/kubedb/installer/raw/${RELEASE}/catalog/kubedb/active_versions.json -o /tmp/kubedb-active-versions.json",
 						"release-automaton kubedb update-example-versions /tmp/kubedb-active-versions.json --workspace=${WORKSPACE}",
-						fmt.Sprintf("release-automaton update-assets %s--release-file=${SCRIPT_ROOT}/releases/${RELEASE}/release.json --workspace=${WORKSPACE}", updateAssetsFlags),
+						UpdateAssetsCmd(hideDocs),
 					},
 					Changelog: api.StandaloneWebsiteChangelog,
 				},

--- a/cmds/kubestash_create_release.go
+++ b/cmds/kubestash_create_release.go
@@ -51,6 +51,13 @@ func NewCmdKubeStashCreateRelease() *cobra.Command {
 func CreateKubeStashReleaseFile() api.Release {
 	prerelease := ""
 	releaseNumber := "v2026.7.10" + prerelease
+	// hideDocs hides this release's docs from the website. When set, the release
+	// is not advertised as the website's version either.
+	hideDocs := false
+	updateAssetsFlags := ""
+	if hideDocs {
+		updateAssetsFlags = "--hide "
+	}
 	return api.Release{
 		ProductLine:       "KubeStash",
 		Release:           releaseNumber,
@@ -122,7 +129,7 @@ func CreateKubeStashReleaseFile() api.Release {
 				// Must come before docs repo, so we can generate the docs_changelog.md
 				"github.com/appscode/static-assets": api.Project{
 					Commands: []string{
-						"release-automaton update-assets --release-file=${SCRIPT_ROOT}/releases/${RELEASE}/release.json --workspace=${WORKSPACE}",
+						fmt.Sprintf("release-automaton update-assets %s--release-file=${SCRIPT_ROOT}/releases/${RELEASE}/release.json --workspace=${WORKSPACE}", updateAssetsFlags),
 					},
 					Changelog: api.StandaloneWebsiteChangelog,
 				},
@@ -146,7 +153,7 @@ func CreateKubeStashReleaseFile() api.Release {
 							"make set-assets-repo ASSETS_REPO_URL=https://github.com/appscode/static-assets",
 							"make docs",
 						},
-						semvers.IsPublicRelease(releaseNumber),
+						!hideDocs && semvers.IsPublicRelease(releaseNumber),
 						"make set-version VERSION=${TAG}",
 					),
 					Changelog: api.SkipChangelog,

--- a/cmds/kubestash_create_release.go
+++ b/cmds/kubestash_create_release.go
@@ -54,10 +54,6 @@ func CreateKubeStashReleaseFile() api.Release {
 	// hideDocs hides this release's docs from the website. When set, the release
 	// is not advertised as the website's version either.
 	hideDocs := false
-	updateAssetsFlags := ""
-	if hideDocs {
-		updateAssetsFlags = "--hide "
-	}
 	return api.Release{
 		ProductLine:       "KubeStash",
 		Release:           releaseNumber,
@@ -129,7 +125,7 @@ func CreateKubeStashReleaseFile() api.Release {
 				// Must come before docs repo, so we can generate the docs_changelog.md
 				"github.com/appscode/static-assets": api.Project{
 					Commands: []string{
-						fmt.Sprintf("release-automaton update-assets %s--release-file=${SCRIPT_ROOT}/releases/${RELEASE}/release.json --workspace=${WORKSPACE}", updateAssetsFlags),
+						UpdateAssetsCmd(hideDocs),
 					},
 					Changelog: api.StandaloneWebsiteChangelog,
 				},

--- a/cmds/kubevault_create_release.go
+++ b/cmds/kubevault_create_release.go
@@ -54,10 +54,6 @@ func CreateKubeVaultReleaseFile() api.Release {
 	// hideDocs hides this release's docs from the website. When set, the release
 	// is not advertised as the website's version either.
 	hideDocs := false
-	updateAssetsFlags := ""
-	if hideDocs {
-		updateAssetsFlags = "--hide "
-	}
 	return api.Release{
 		ProductLine:       "KubeVault",
 		Release:           releaseNumber,
@@ -129,7 +125,7 @@ func CreateKubeVaultReleaseFile() api.Release {
 				// Must come before docs repo, so we can generate the docs_changelog.md
 				"github.com/appscode/static-assets": api.Project{
 					Commands: []string{
-						fmt.Sprintf("release-automaton update-assets %s--release-file=${SCRIPT_ROOT}/releases/${RELEASE}/release.json --workspace=${WORKSPACE}", updateAssetsFlags),
+						UpdateAssetsCmd(hideDocs),
 					},
 					Changelog: api.StandaloneWebsiteChangelog,
 				},

--- a/cmds/kubevault_create_release.go
+++ b/cmds/kubevault_create_release.go
@@ -51,6 +51,13 @@ func NewCmdKubeVaultCreateRelease() *cobra.Command {
 func CreateKubeVaultReleaseFile() api.Release {
 	prerelease := "-rc.1"
 	releaseNumber := "v2026.5.18" + prerelease
+	// hideDocs hides this release's docs from the website. When set, the release
+	// is not advertised as the website's version either.
+	hideDocs := false
+	updateAssetsFlags := ""
+	if hideDocs {
+		updateAssetsFlags = "--hide "
+	}
 	return api.Release{
 		ProductLine:       "KubeVault",
 		Release:           releaseNumber,
@@ -122,7 +129,7 @@ func CreateKubeVaultReleaseFile() api.Release {
 				// Must come before docs repo, so we can generate the docs_changelog.md
 				"github.com/appscode/static-assets": api.Project{
 					Commands: []string{
-						"release-automaton update-assets --release-file=${SCRIPT_ROOT}/releases/${RELEASE}/release.json --workspace=${WORKSPACE}",
+						fmt.Sprintf("release-automaton update-assets %s--release-file=${SCRIPT_ROOT}/releases/${RELEASE}/release.json --workspace=${WORKSPACE}", updateAssetsFlags),
 					},
 					Changelog: api.StandaloneWebsiteChangelog,
 				},
@@ -146,7 +153,7 @@ func CreateKubeVaultReleaseFile() api.Release {
 							"make set-assets-repo ASSETS_REPO_URL=https://github.com/appscode/static-assets",
 							"make docs",
 						},
-						semvers.IsPublicRelease(releaseNumber),
+						!hideDocs && semvers.IsPublicRelease(releaseNumber),
 						"make set-version VERSION=${TAG}",
 					),
 					Changelog: api.SkipChangelog,

--- a/cmds/stash_create_release.go
+++ b/cmds/stash_create_release.go
@@ -51,6 +51,13 @@ func NewCmdStashCreateRelease() *cobra.Command {
 func CreateStashReleaseFile() api.Release {
 	prerelease := ""
 	releaseNumber := "v2025.10.17" + prerelease
+	// hideDocs hides this release's docs from the website. When set, the release
+	// is not advertised as the website's version either.
+	hideDocs := false
+	updateAssetsFlags := ""
+	if hideDocs {
+		updateAssetsFlags = "--hide "
+	}
 	updateVars := "release-automaton update-vars " +
 		"--env-file=${WORKSPACE}/Makefile.env " +
 		"--vars=STASH_VERSION=${STASHED_STASH_TAG} " +
@@ -273,7 +280,7 @@ func CreateStashReleaseFile() api.Release {
 				// Must come before docs repo, so we can generate the docs_changelog.md
 				"github.com/appscode/static-assets": api.Project{
 					Commands: []string{
-						"release-automaton update-assets --release-file=${SCRIPT_ROOT}/releases/${RELEASE}/release.json --workspace=${WORKSPACE}",
+						fmt.Sprintf("release-automaton update-assets %s--release-file=${SCRIPT_ROOT}/releases/${RELEASE}/release.json --workspace=${WORKSPACE}", updateAssetsFlags),
 					},
 					Changelog: api.StandaloneWebsiteChangelog,
 				},
@@ -297,7 +304,7 @@ func CreateStashReleaseFile() api.Release {
 							"make set-assets-repo ASSETS_REPO_URL=https://github.com/appscode/static-assets",
 							"make docs",
 						},
-						semvers.IsPublicRelease(releaseNumber),
+						!hideDocs && semvers.IsPublicRelease(releaseNumber),
 						"make set-version VERSION=${TAG}",
 					),
 					Changelog: api.SkipChangelog,

--- a/cmds/stash_create_release.go
+++ b/cmds/stash_create_release.go
@@ -54,10 +54,6 @@ func CreateStashReleaseFile() api.Release {
 	// hideDocs hides this release's docs from the website. When set, the release
 	// is not advertised as the website's version either.
 	hideDocs := false
-	updateAssetsFlags := ""
-	if hideDocs {
-		updateAssetsFlags = "--hide "
-	}
 	updateVars := "release-automaton update-vars " +
 		"--env-file=${WORKSPACE}/Makefile.env " +
 		"--vars=STASH_VERSION=${STASHED_STASH_TAG} " +
@@ -280,7 +276,7 @@ func CreateStashReleaseFile() api.Release {
 				// Must come before docs repo, so we can generate the docs_changelog.md
 				"github.com/appscode/static-assets": api.Project{
 					Commands: []string{
-						fmt.Sprintf("release-automaton update-assets %s--release-file=${SCRIPT_ROOT}/releases/${RELEASE}/release.json --workspace=${WORKSPACE}", updateAssetsFlags),
+						UpdateAssetsCmd(hideDocs),
 					},
 					Changelog: api.StandaloneWebsiteChangelog,
 				},

--- a/cmds/utils.go
+++ b/cmds/utils.go
@@ -52,3 +52,15 @@ func TagP(v, prerelease string) *string {
 	tag := computeTag(v, prerelease)
 	return &tag
 }
+
+// UpdateAssetsCmd builds the `release-automaton update-assets` command for a
+// release. When hideDocs is true, the release's docs are hidden from the
+// website via the --hide flag (and callers should also skip advertising it as
+// the website's version).
+func UpdateAssetsCmd(hideDocs bool) string {
+	flags := ""
+	if hideDocs {
+		flags = "--hide "
+	}
+	return fmt.Sprintf("release-automaton update-assets %s--release-file=${SCRIPT_ROOT}/releases/${RELEASE}/release.json --workspace=${WORKSPACE}", flags)
+}

--- a/cmds/voyager_create_release.go
+++ b/cmds/voyager_create_release.go
@@ -51,6 +51,13 @@ func NewCmdVoyagerCreateRelease() *cobra.Command {
 func CreateVoyagerReleaseFile() api.Release {
 	prerelease := ""
 	releaseNumber := "v2026.3.23" + prerelease
+	// hideDocs hides this release's docs from the website. When set, the release
+	// is not advertised as the website's version either.
+	hideDocs := false
+	updateAssetsFlags := ""
+	if hideDocs {
+		updateAssetsFlags = "--hide "
+	}
 	return api.Release{
 		ProductLine:       "Voyager",
 		Release:           releaseNumber,
@@ -101,7 +108,7 @@ func CreateVoyagerReleaseFile() api.Release {
 				// Must come before docs repo, so we can generate the docs_changelog.md
 				"github.com/appscode/static-assets": api.Project{
 					Commands: []string{
-						"release-automaton update-assets --release-file=${SCRIPT_ROOT}/releases/${RELEASE}/release.json --workspace=${WORKSPACE}",
+						fmt.Sprintf("release-automaton update-assets %s--release-file=${SCRIPT_ROOT}/releases/${RELEASE}/release.json --workspace=${WORKSPACE}", updateAssetsFlags),
 					},
 					Changelog: api.StandaloneWebsiteChangelog,
 				},
@@ -125,7 +132,7 @@ func CreateVoyagerReleaseFile() api.Release {
 							"make set-assets-repo ASSETS_REPO_URL=https://github.com/appscode/static-assets",
 							"make docs",
 						},
-						semvers.IsPublicRelease(releaseNumber),
+						!hideDocs && semvers.IsPublicRelease(releaseNumber),
 						"make set-version VERSION=${TAG}",
 					),
 					Changelog: api.SkipChangelog,

--- a/cmds/voyager_create_release.go
+++ b/cmds/voyager_create_release.go
@@ -54,10 +54,6 @@ func CreateVoyagerReleaseFile() api.Release {
 	// hideDocs hides this release's docs from the website. When set, the release
 	// is not advertised as the website's version either.
 	hideDocs := false
-	updateAssetsFlags := ""
-	if hideDocs {
-		updateAssetsFlags = "--hide "
-	}
 	return api.Release{
 		ProductLine:       "Voyager",
 		Release:           releaseNumber,
@@ -108,7 +104,7 @@ func CreateVoyagerReleaseFile() api.Release {
 				// Must come before docs repo, so we can generate the docs_changelog.md
 				"github.com/appscode/static-assets": api.Project{
 					Commands: []string{
-						fmt.Sprintf("release-automaton update-assets %s--release-file=${SCRIPT_ROOT}/releases/${RELEASE}/release.json --workspace=${WORKSPACE}", updateAssetsFlags),
+						UpdateAssetsCmd(hideDocs),
 					},
 					Changelog: api.StandaloneWebsiteChangelog,
 				},


### PR DESCRIPTION
## What

When a kubedb release passes `--hide` to `release-automaton update-assets`, the release's docs are hidden from the website. Previously, `make set-operator-version` still ran for public releases, so a hidden release could still be advertised as the website's operator version — an inconsistency.

## Change

In `cmds/kubedb_create_release.go`, tie the `--hide` flag and the `set-operator-version` step to a single `hideDocs` toggle:

- Added a `hideDocs` variable (currently `true`, matching the existing hardcoded `--hide`).
- The `update-assets` command conditionally includes `--hide` based on `hideDocs`.
- `make set-operator-version` now only runs when `!hideDocs && semvers.IsPublicRelease(releaseNumber)`.

To make a future release visible again, set `hideDocs := false` in one place and both behaviors adjust together.